### PR TITLE
Fix for breaking search button on sidebar nav

### DIFF
--- a/app/styles/_sidebar_nav.scss
+++ b/app/styles/_sidebar_nav.scss
@@ -128,6 +128,9 @@
         height: 38px;
         text-shadow: none;
         @include transition(opacity);
+        position: absolute;
+        top: 10px;
+        right: 15px;
 
         &:hover {
             opacity: .8;


### PR DESCRIPTION
Fixes #122 by making the search button absolutely positioned so if scrollbars (or anything else) tighten up the layout, the search button doesn't drop down onto the next line.