### PR TITLE
Changed let to var to increase browser compatibility.  Only the lates…

### DIFF
--- a/app/components/nav-menu.js
+++ b/app/components/nav-menu.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend(UserSession, {
     isShowing: false,
     
     _setup: function() {
-        let nav = this.get("nav");
+        var nav = this.get("nav");
         nav.closeSubnav = function() {
             this.set('isShowing', false);
         }.bind(this);


### PR DESCRIPTION
…t versions of Chrome support this ES6 feature.  (https://kangax.github.io/compat-table/es6/)

I initially tried to follow the setup instructions, which were quite good, and run the app in firefox.  So I was a bit flummoxed when it didn't give me a login page.  After some debugging and searching I found this to be the problem.